### PR TITLE
fixing a problem with the post-install script

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 507300c458c1db3bf42e8168530105d4a96d0bbdaa910ebf9d5bf3b4df65c414
 
 build:
-  number: 3
+  number: 4
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   skip: True  # [win]
 
@@ -21,6 +21,7 @@ requirements:
     - pip
   run:
     - python
+    - jupyter
     - ipywidgets >=6.0.0
     - traitlets >=4.3.0
     - pillow

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" enable ipywe --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" enable ipywe --py --sys-prefix # > /dev/null 2>&1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" disable ipywe --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" disable ipywe --py --sys-prefix # > /dev/null 2>&1


### PR DESCRIPTION
When it is installed lately, it seems jupyter-nbextension binary was moved to different pkg and the post-install script fails. adding "jupyter" as a runtime dep fixed this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
